### PR TITLE
Add governance file detection metrics

### DIFF
--- a/maturity_tools/maturity_tools/github_call.py
+++ b/maturity_tools/maturity_tools/github_call.py
@@ -9,7 +9,7 @@ import threading
 import time
 import requests
 from typing import Any, Dict, Optional
-from maturity_tools.queries import branches_query, commits_query, releases_query, issues_query, pr_query
+from maturity_tools.queries import branches_query, commits_query, releases_query, issues_query, pr_query, governance_query
 import pandas as pd
 
 
@@ -550,3 +550,37 @@ def process_prs(variables, GITHUB_TOKEN) -> Optional[pd.DataFrame]:
     # Ensure stable schema even when there are zero PRs (pd.DataFrame([]) has no columns).
     df_prs = pd.DataFrame(pr_data_list)
     return df_prs.reindex(columns=PR_COLUMNS)
+
+
+def fetch_governance_files(variables: dict, token: str) -> dict[str, bool]:
+    result = github_api_call(
+        governance_query,
+        variables,
+        token,
+        request_name="governance_files",
+    )
+    repo_data = result.get("data", {}).get("repository", {})
+
+    has_security = any(
+        repo_data.get(key) is not None
+        for key in ("security_md", "security_rst", "security_txt")
+    )
+    has_governance = any(
+        repo_data.get(key) is not None
+        for key in ("governance_md", "governance_rst")
+    )
+    has_code_of_conduct = any(
+        repo_data.get(key) is not None
+        for key in ("code_of_conduct_md", "code_of_conduct_gh")
+    )
+    has_containerization = any(
+        repo_data.get(key) is not None
+        for key in ("dockerfile", "docker_compose_yml", "docker_compose_yaml", "containerfile")
+    )
+
+    return {
+        "has_security_policy": has_security,
+        "has_governance": has_governance,
+        "has_code_of_conduct": has_code_of_conduct,
+        "has_containerization": has_containerization,
+    }

--- a/maturity_tools/maturity_tools/queries.py
+++ b/maturity_tools/maturity_tools/queries.py
@@ -159,6 +159,24 @@ query($owner: String!, $repo: String!, $first_issues: Int!, $after_issues: Strin
 }
 """
 
+governance_query = """
+query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    security_md: object(expression: "HEAD:SECURITY.md") { __typename }
+    security_rst: object(expression: "HEAD:SECURITY.rst") { __typename }
+    security_txt: object(expression: "HEAD:.github/SECURITY.md") { __typename }
+    governance_md: object(expression: "HEAD:GOVERNANCE.md") { __typename }
+    governance_rst: object(expression: "HEAD:GOVERNANCE.rst") { __typename }
+    code_of_conduct_md: object(expression: "HEAD:CODE_OF_CONDUCT.md") { __typename }
+    code_of_conduct_gh: object(expression: "HEAD:.github/CODE_OF_CONDUCT.md") { __typename }
+    dockerfile: object(expression: "HEAD:Dockerfile") { __typename }
+    docker_compose_yml: object(expression: "HEAD:docker-compose.yml") { __typename }
+    docker_compose_yaml: object(expression: "HEAD:docker-compose.yaml") { __typename }
+    containerfile: object(expression: "HEAD:Containerfile") { __typename }
+  }
+}
+"""
+
 pr_query = """
 query($owner: String!, $repo: String!, $first_prs: Int!, $after_prs: String) {
   repository(owner: $owner, name: $repo) {

--- a/scripts/refresh_cache.py
+++ b/scripts/refresh_cache.py
@@ -11,6 +11,7 @@ repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 from maturity_tools.analyzers import CommitAnalyzer, IssuePRAnalyzer, ReleaseAnalyzer
 from maturity_tools.github_call import (
     fetch_commit_page,
+    fetch_governance_files,
     github_api_call,
     process_branches,
     process_commits,
@@ -736,6 +737,11 @@ def compute_repo_metrics(session, run_id, repo_info: dict) -> None:
     )
 
 
+def compute_governance_metrics(session, run_id, governance_flags: dict) -> None:
+    for name, value in governance_flags.items():
+        add_metric(session, run_id=run_id, scope="governance", name=name, value=int(value))
+
+
 def collect_for_repo(
     session,
     owner,
@@ -924,6 +930,20 @@ def collect_for_repo(
             owner,
             repo,
             _format_duration(time.monotonic() - repo_metrics_start),
+        )
+
+        status_logger.info("owner=%s repo=%s stage=governance status=start", owner, repo)
+        governance_start = time.monotonic()
+        try:
+            governance_flags = fetch_governance_files({"owner": owner, "repo": repo}, token)
+            compute_governance_metrics(session, run.id, governance_flags)
+        except Exception:
+            logger.warning("Failed to fetch governance files for %s/%s", owner, repo, exc_info=True)
+        status_logger.info(
+            "owner=%s repo=%s stage=governance status=ok duration=%s",
+            owner,
+            repo,
+            _format_duration(time.monotonic() - governance_start),
         )
 
     if not commits_df_recent.empty:


### PR DESCRIPTION
## Summary

- Add a new `governance_query` GraphQL query that checks for the existence of key project governance and infrastructure files
- Detect: **Security Policy** (`SECURITY.md`, `.github/SECURITY.md`), **Governance** (`GOVERNANCE.md`), **Code of Conduct** (`CODE_OF_CONDUCT.md`), **Containerization** (`Dockerfile`, `docker-compose.yml`, `Containerfile`)
- Store results as boolean metrics under the `governance` scope via `add_metric()`
- Integrated into the `refresh_cache.py` collection pipeline with proper error handling and status logging

This covers 3 subtasks from #18: Security Policy/Guidelines, Governance file, and Containerization.

Partial fix for #18

## Test plan

- [ ] Run `python scripts/refresh_cache.py --owner <org> --repo <repo>` and verify governance metrics appear in the database
- [ ] Query the API at `/repos/{owner}/{repo}/metrics` and verify `governance` scope contains `has_security_policy`, `has_governance`, `has_code_of_conduct`, `has_containerization`
- [ ] Test against a repo with known governance files (e.g., one with SECURITY.md) and verify `1` is returned
- [ ] Test against a repo without governance files and verify `0` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)